### PR TITLE
arreglos frontend

### DIFF
--- a/frontend/src/components/convenio/sumasdescuentos.component.js
+++ b/frontend/src/components/convenio/sumasdescuentos.component.js
@@ -45,6 +45,11 @@ export default function SumasDescuentos(props) {
     const [inputTipo, setInputTipo] = React.useState('');
     const [listaTipos, setListaTipos] = React.useState(['Suma Remunerativa', 'Suma No Remunerativa', 'Descuento Remunerativo', 'Descuento No Remunerativo']);
 
+    const [valueSobre, setValueSobre] = React.useState('');
+    const [inputSobre, setInputSobre] = React.useState('');
+    const [listaSobres, setListaSobres] = React.useState(['sueldo_basico', 'sueldo_bruto_hora', 'sueldo_bruto_dia', 'monto_fijo', 'total_sumas_rem']);
+
+
     const [sumaRemunerativa, setSumaRemunerativa] = React.useState('');
     const [unidadMonto, setUnidadMonto] = React.useState('');
 
@@ -87,7 +92,7 @@ export default function SumasDescuentos(props) {
     function addSumaRemunerativa() {
 
         //todo completo?
-        if (orden === '' || nombre === '' || unidad === '' || cantidad === '' || inputTipo === '') {
+        if (orden === '' || nombre === '' || unidad === '' || cantidad === '' || inputTipo === '' || inputSobre === '') {
             swal("Error!", "No deje nada vacio!", "error");
             return 0
         }
@@ -98,6 +103,7 @@ export default function SumasDescuentos(props) {
             unidad: unidad,
             cantidad: cantidad,
             tipo: inputTipo,
+            sobre: inputSobre,
 
         }
 
@@ -185,7 +191,7 @@ export default function SumasDescuentos(props) {
         return listdic
     }
 
-   
+
 
     function obtenerFilas(diclist) {
         console.log(diclist);
@@ -228,7 +234,7 @@ export default function SumasDescuentos(props) {
             .then(response => {
                 setRows(obtenerFilas(response.data));
                 setListaConvenios(onlyConvenios(response.data))
-                
+
                 console.log(response.data);
             })
             .catch(e => {
@@ -322,19 +328,12 @@ export default function SumasDescuentos(props) {
                             />
                             <Autocomplete
                                 id="country-select-tipo"
-
                                 value={valueTipo}
                                 onChange={(event, newValue) => {
-
-
                                     setValueTipo(newValue);
-
-
-
                                 }}
                                 inputValue={inputTipo}
                                 onInputChange={(event, newInputValue) => {
-
                                     setInputTipo(newInputValue);
                                 }}
                                 style={{ width: 250, margin: 10 }}
@@ -347,7 +346,6 @@ export default function SumasDescuentos(props) {
                                 renderOption={(option) => (
                                     <React.Fragment>
                                         <span>{option}</span>
-
                                     </React.Fragment>
                                 )}
                                 renderInput={(params) => (
@@ -412,6 +410,42 @@ export default function SumasDescuentos(props) {
 
 
                                 variant="outlined"
+                            />
+
+
+                            <Autocomplete
+                                id="sobre-select-tipo"
+                                value={valueSobre}
+                                onChange={(event, newValue) => {
+                                    setValueSobre(newValue);
+                                }}
+                                inputValue={inputSobre}
+                                onInputChange={(event, newInputValue) => {
+                                    setInputSobre(newInputValue);
+                                }}
+                                style={{ width: 250, margin: 10 }}
+                                options={listaSobres}
+                                classes={{
+                                    option: classes.option,
+                                }}
+                                autoHighlight
+                                getOptionLabel={(option) => option}
+                                renderOption={(option) => (
+                                    <React.Fragment>
+                                        <span>{option}</span>
+                                    </React.Fragment>
+                                )}
+                                renderInput={(params) => (
+                                    <TextField
+                                        {...params}
+                                        label="Sobre"
+                                        variant="outlined"
+                                        inputProps={{
+                                            ...params.inputProps,
+                                            autoComplete: 'new-password', // disable autocomplete and autofill
+                                        }}
+                                    />
+                                )}
                             />
 
 

--- a/frontend/src/components/reporte/pdf.component.js
+++ b/frontend/src/components/reporte/pdf.component.js
@@ -62,7 +62,7 @@ const styles = StyleSheet.create({
         flexDirection: 'row',
         marginLeft: 5,
         marginRight: 5,
-        height: '42%',
+        height: '40%',
     },
     infoSUP: {
         fontSize: 13,

--- a/frontend/src/components/sueldos/parametros/adicionales.component.js
+++ b/frontend/src/components/sueldos/parametros/adicionales.component.js
@@ -74,16 +74,7 @@ export default function Adicionales(props) {
 
 
 
-                <Paper elevation={3} style={{ minWidth: 250, margin: 10, backgroundColor: '#91e1e938', padding: 10, paddingLeft: 25 }}>
-                    Adicional vidrierista
-                    <Switch
-                        checked={props.props.adicionalVidrierista}
-                        onChange={props.props.onChangeAdicionalVidrierista}
-                        name="checkedA"
-                        color='primary'
-                        inputProps={{ 'aria-label': 'primary checkbox' }}
-                    />
-                </Paper>
+                
                 <Paper elevation={3} style={{ minWidth: 250, margin: 10, backgroundColor: '#91e1e938', padding: 10, paddingLeft: 25 }}>
                     Adicional por asistencia
                     <Switch

--- a/frontend/src/components/sueldos/parametros/basicos.component.js
+++ b/frontend/src/components/sueldos/parametros/basicos.component.js
@@ -54,6 +54,8 @@ export default function Basicos(props) {
         checkedD: false,
         checkedE: false,
         checkedF: false,
+        checkedV: false,
+        checkedS: false,
     });
 
     const handleChange = (event) => {
@@ -152,6 +154,17 @@ export default function Basicos(props) {
                     )}
                 />
 
+<Paper elevation={3} style={{ minWidth: 250, margin: 10, backgroundColor: '#91e1e938', padding: 10, paddingLeft: 25 }}>
+                    Adicional vidrierista
+                    <Switch
+                        checked={props.props.adicionalVidrierista}
+                        onChange={props.props.onChangeAdicionalVidrierista}
+                        name="checkedV"
+                        color='primary'
+                        inputProps={{ 'aria-label': 'primary checkbox' }}
+                    />
+                </Paper>
+
 
 
                 <Paper elevation={3} style={{ minWidth: 250, margin: 10, backgroundColor: '#91e1e938', padding: 10, paddingLeft: 25, display: 'none' }}>
@@ -232,6 +245,17 @@ alignItems="center"
                     />
                 </Paper>
 
+                <Paper elevation={3} style={{ minWidth: 250, margin: 10, backgroundColor: '#91e1e938', padding: 10, paddingLeft: 25 }}>
+                    Afiliado sindicato
+                    <Switch
+                        checked={props.props.afiliadoSindicato}
+                        onChange={props.props.onChangeAfiliadoSindicato}
+                        name="checkedS"
+                        color='primary'
+                        inputProps={{ 'aria-label': 'primary checkbox' }}
+                    />
+                </Paper>
+
 
 
 
@@ -247,7 +271,7 @@ alignItems="center"
                         inputProps={{ 'aria-label': 'primary checkbox' }}
                     />
                 </Paper>
-                <Paper elevation={3} style={{ minWidth: 250, margin: 10, backgroundColor: '#91e1e938', padding: 10, paddingLeft: 25 }}>
+                <Paper elevation={3} style={{ minWidth: 250, margin: 10, backgroundColor: '#91e1e938', padding: 10, paddingLeft: 25, display: "none" }}>
                     Aporte solidario OSECAC
                     <Switch
                         checked={props.props.aporteSolidarioOsecac}
@@ -257,7 +281,7 @@ alignItems="center"
                         inputProps={{ 'aria-label': 'primary checkbox' }}
                     />
                 </Paper>
-                <Paper elevation={3} style={{ minWidth: 250, margin: 10, backgroundColor: '#91e1e938', padding: 10, paddingLeft: 25 }}>
+                <Paper elevation={3} style={{ minWidth: 250, margin: 10, backgroundColor: '#91e1e938', padding: 10, paddingLeft: 25, display: "none" }}>
                     Aporte OSECAC
                     <Switch
                         checked={props.props.aporteOsecac}

--- a/frontend/src/components/sueldos/parametros/feriados.component.js
+++ b/frontend/src/components/sueldos/parametros/feriados.component.js
@@ -98,7 +98,7 @@ export default function Adicionales(props) {
 
                     }}
 
-                    style={{ width: 250 }}
+                    style={{ width: 250, display: "none" }}
                     options={exposiciones}
                     classes={{
                         option: classes.option,
@@ -171,7 +171,7 @@ export default function Adicionales(props) {
 
                     }}
 
-                    style={{ width: 250 }}
+                    style={{ width: 250, display: "none" }}
                     options={criteriost}
                     classes={{
                         option: classes.option,
@@ -207,7 +207,7 @@ export default function Adicionales(props) {
 
                     }}
 
-                    style={{ width: 250, marginLeft: 15 }}
+                    style={{ width: 250, marginLeft: 15, display: "none" }}
                     options={criteriosNot}
                     classes={{
                         option: classes.option,

--- a/frontend/src/components/sueldos/parametros/vacaciones.component.js
+++ b/frontend/src/components/sueldos/parametros/vacaciones.component.js
@@ -141,7 +141,7 @@ export default function Adicionales(props) {
                 <TextField
                     label="Antigüedad (años)"
                     placeholder='0'
-                    style={{ width: 250, margin: 12, marginLeft: 12 }}
+                    style={{ width: 250, margin: 12, marginLeft: 12, display: "none" }}
                     className={clsx(classes.margin, classes.textField)}
                     type="number"
                     variant="outlined"

--- a/frontend/src/components/sueldos/sueldo.component.js
+++ b/frontend/src/components/sueldos/sueldo.component.js
@@ -76,6 +76,7 @@ export default function Sueldos(props) {
 
     const [porcentajeXzona, setPorcentajeXzona] = React.useState('');
     const [adicionalVidrierista, setAdicionalVidrierista] = React.useState(false);
+    const [afiliadoSindicato, setAfiliadoSindicato] = React.useState(false);
     const [antiguedadAcumulativa, setAntiguedadAcumulativa] = React.useState(false);
     const [antiguedadComputo, setAntiguedadComputo] = React.useState('');
     const [porcentajeAntiguedadxAño, setPorcentajeAntiguedadxAño] = React.useState('');
@@ -385,6 +386,9 @@ export default function Sueldos(props) {
     function onChangeAdicionalVidrierista(e) {
         setAdicionalVidrierista(e.target.checked);
     }
+    function onChangeAfiliadoSindicato(e) {
+        setAfiliadoSindicato(e.target.checked);
+    }
     function onChangeAntiguedadAcumulativa(e) {
         setAntiguedadAcumulativa(e.target.checked);
     }
@@ -546,6 +550,7 @@ export default function Sueldos(props) {
 
         setPorcentajeXzona('');
         setAdicionalVidrierista(false);
+        setAfiliadoSindicato(false);
         setAntiguedadAcumulativa(false);
         setAntiguedadComputo('');
         setPorcentajeAntiguedadxAño('');
@@ -624,7 +629,7 @@ export default function Sueldos(props) {
             auxDic = {
                 codigo: detalles.descuentos_rem_sac[i].orden,
                 detalle: detalles.descuentos_rem_sac[i].name,
-                cantidad: ' '+parseFloat(detalles.descuentos_rem_sac[i].cantidad )*100+'%',
+                cantidad: ' '+parseFloat(detalles.descuentos_rem_sac[i].unidad )*100+'%',
                 haber: '',
                 deduccion: parseFloat(detalles.descuentos_rem_sac[i].subtotal).toFixed(2),
             }
@@ -640,10 +645,23 @@ export default function Sueldos(props) {
         var listDic = [];
         var auxDic = {};
 
+        console.log(detalles);
+
+        var auxV = detalles?.sumas_rem;
+        var valorVacaciones = 0;
+        if (auxV) {
+            for (let index = 0; index < auxV.length; index++) {
+                if (auxV[index].name = 'Vacaciones'){
+                    valorVacaciones = auxV[index].cantidad;
+                }
+                
+            }
+        }
+
         auxDic = {
             codigo: '000',
             detalle: 'Basico',
-            cantidad: '30',
+            cantidad: 30 - valorVacaciones,
             haber: parseFloat(detalles.sueldo_basico).toFixed(2),
             deduccion: '',
         }
@@ -652,6 +670,9 @@ export default function Sueldos(props) {
 
 
         for (let i = 0; i < detalles.sumas_rem.length; i++) {
+
+            if (detalles.sumas_rem[i].name !== "Vacaciones" || (detalles.sumas_rem[i].name == "Vacaciones" && detalles.sumas_rem[i].cantidad > 0 )) {
+
             auxDic = {
                 codigo: detalles.sumas_rem[i].orden,
                 detalle: detalles.sumas_rem[i].name,
@@ -660,6 +681,10 @@ export default function Sueldos(props) {
                 deduccion: ''
             }
             listDic.push(auxDic);
+
+        }
+
+
         }
 
         for (let i = 0; i < detalles.descuentos_rem.length; i++) {
@@ -810,6 +835,7 @@ export default function Sueldos(props) {
 
             porcentajeXzona: porcentajeXzona,
             adicionalVidrierista: adicionalVidrierista,
+            afiliadoSindicato: afiliadoSindicato,
             antiguedadAcumulativa: antiguedadAcumulativa,
             antiguedadComputo: antiguedadComputo, //'mes siguiente' o 'mes cumplido'  
             porcentajeAntiguedadxAño: porcentajeAntiguedadxAño,
@@ -819,8 +845,12 @@ export default function Sueldos(props) {
             //Feriados
             exposicionFeriado: exposicionFeriado, //'diferencia' o 'sumar y restar'  
             diasNoTrabajados: diasNoTrabajados,
+
             criterioTrabajados: criterioTrabajados, //'Base 30/25' o 'todo base 30' o 'todo base 25'  
             criterioNoTrabajados: criterioNoTrabajados, //'base 30' o 'base 25'  
+
+            diasTrabajadosFeriado: diasTrabajados,
+            diasNoTrabajadosFeriado: diasNoTrabajados,
 
             diasTrabajados: diasTrabajados,
 
@@ -1084,6 +1114,8 @@ export default function Sueldos(props) {
                         porcentajeXzona={porcentajeXzona}
                         onChangeAdicionalVidrierista={onChangeAdicionalVidrierista}
                         adicionalVidrierista={adicionalVidrierista}
+                        onChangeAfiliadoSindicato={onChangeAfiliadoSindicato}
+                        afiliadoSindicato={afiliadoSindicato}
                         onChangeAntiguedadAcumulativa={onChangeAntiguedadAcumulativa}
                         antiguedadAcumulativa={antiguedadAcumulativa}
                         onChangeAntiguedadComputo={onChangeAntiguedadComputo}
@@ -1126,8 +1158,8 @@ export default function Sueldos(props) {
                         diasInculpable={diasInculpable}
                         onChangeLicenciaSinGoce={onChangeLicenciaSinGoce}
                         setLicenciaSinGoce={setLicenciaSinGoce}
-                        onChangeDiasInculpable={onChangeDiasInculpable}
-                        diasInculpable={diasInculpable}
+                        //onChangeDiasInculpable={onChangeDiasInculpable}
+                        //diasInculpable={diasInculpable}
                         onChangeNombreLicencia={onChangeNombreLicencia}
                         setNombreLicencia={setNombreLicencia}
 

--- a/frontend/src/components/sueldos/utilidades.component.js
+++ b/frontend/src/components/sueldos/utilidades.component.js
@@ -101,12 +101,13 @@ export default function Utilidades(props) {
         >
           <Tab label="Opciones basicas" icon={<ListIcon />} {...a11yProps(0)} />
           
-          <Tab label="Adicionales" icon={<LibraryAddIcon />} {...a11yProps(1)} />
-          <Tab label="Feriados" icon={<TodayIcon />} {...a11yProps(2)} />
-          <Tab label="Horas extras" icon={<ScheduleIcon />} {...a11yProps(3)} />
-          <Tab label="Vacaciones" icon={<FlightTakeoffIcon />} {...a11yProps(4)} />
-          <Tab label="Licencias" icon={<GavelIcon />} {...a11yProps(5)} />
-          <Tab label="Descuentos" icon={<TrendingDownIcon />} {...a11yProps(6)} />
+          
+          <Tab label="Feriados" icon={<TodayIcon />} {...a11yProps(1)} />
+          <Tab label="Horas extras" icon={<ScheduleIcon />} {...a11yProps(2)} />
+          <Tab label="Vacaciones" icon={<FlightTakeoffIcon />} {...a11yProps(3)} />
+          <Tab label="Licencias" icon={<GavelIcon />} {...a11yProps(4)} />
+         {/*  <Tab label="Adicionales" icon={<LibraryAddIcon />} {...a11yProps(5)} /> */}
+         {/*  <Tab label="Descuentos" icon={<TrendingDownIcon />} {...a11yProps(6)} /> */}
         </Tabs>
       </AppBar>
       <TabPanel value={value} index={0}   className={classes.tabs}>
@@ -118,42 +119,43 @@ export default function Utilidades(props) {
 
     
 
+      
       <TabPanel value={value} index={1}  className={classes.tabs}>
-      <Adicionales
-          onChangeCategoria={onChangeCategoria}
-          props={props}
-        />
-      </TabPanel>
-      <TabPanel value={value} index={2}  className={classes.tabs}>
       <Feriados
           onChangeCategoria={onChangeCategoria}
           props={props}
         />
       </TabPanel>
-      <TabPanel value={value} index={3}  className={classes.tabs}>
+      <TabPanel value={value} index={2}  className={classes.tabs}>
       <Extras
           onChangeCategoria={onChangeCategoria}
           props={props}
         />
       </TabPanel>
-      <TabPanel value={value} index={4}  className={classes.tabs}>
+      <TabPanel value={value} index={3}  className={classes.tabs}>
       <Vacaciones
           onChangeCategoria={onChangeCategoria}
           props={props}
         />
       </TabPanel>
-      <TabPanel value={value} index={5}  className={classes.tabs}>
+      <TabPanel value={value} index={4}  className={classes.tabs}>
       <Licencias
           onChangeCategoria={onChangeCategoria}
           props={props}
         />
       </TabPanel>
-      <TabPanel value={value} index={6}  className={classes.tabs}>
+      {/* <TabPanel value={value} index={6}  className={classes.tabs}>
       <Descuentos
           onChangeCategoria={onChangeCategoria}
           props={props}
         />
-      </TabPanel>
+      </TabPanel> */}
+      {/* <TabPanel value={value} index={1}  className={classes.tabs}>
+      <Adicionales
+          onChangeCategoria={onChangeCategoria}
+          props={props}
+        />
+      </TabPanel> */}
     </div>
   );
 }


### PR DESCRIPTION
se cambia la cantidad del basico, descontando dias de vacaciones. Cuando no hay valores de vacaciones no se muestra. En convenios se agrega el atributo sobre. Al calcular el SAC se arregla el error de cantidades de 100%. Se cambia el nombre de los input de feriado, y se ocultan los inputs extras. Se oculta lo referido a descuentos. Se oculta lo referido a adicionales, excepto por adicional vidrierista que se mueve a basico. En vacaciones vuela antiguedad. En basico se oculta inputs de OSECAC y se agrega input boolean de afiliado sindicato. Se arregla el alto del pdf.